### PR TITLE
🔒 chore: 在 .gitignore 中添加 .env 防止敏感信息泄露

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 .docusaurus/
 .cache-loader/
 .DS_Store
+.env
 .env.local
 .env*.local
 npm-debug.log*


### PR DESCRIPTION
## Summary
- 在 `.gitignore` 中添加 `.env` 条目
- 当前只忽略了 `.env.local` 和 `.env*.local`，裸 `.env` 文件可能被误提交，存在敏感信息泄露风险

## 改动
仅一行：在 `.gitignore` 中 `.DS_Store` 之后添加 `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)